### PR TITLE
Tmux, color change and solidity

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,10 +1,12 @@
 local config_dir = vim.fn.stdpath("config")
 
--- Importing Keymaps and Settings
-require("core.settings")
-require("core.keymaps")
 -- Importing Lua Configuration Files
 require("core.plugins")
+
+-- Importing Keymaps and Settings
+package.loaded["core.settings"] = nil
+require("core.settings")
+require("core.keymaps")
 
 -- Importing Vim scripts
 vim.cmd.source(config_dir .. "/functions.vim")

--- a/lua/core/plugin_config/lsp-config.lua
+++ b/lua/core/plugin_config/lsp-config.lua
@@ -4,8 +4,8 @@ return function ()
 
     local servers = {
         "lua_ls",
+        "solidity_ls_nomicfoundation",
         -- "clang",
-        -- "solidity_ls_nomicfoundation",
         -- "rust_analyzer",
     }
 
@@ -21,8 +21,7 @@ return function ()
         vim.keymap.set('n', 'gd', vim.lsp.buf.definition, {})
         vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, {})
         vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, {})
-
-        vim.keymap.set('n', 'K', vim.lsp.buf.hover, {})
+vim.keymap.set('n', 'K', vim.lsp.buf.hover, {})
         vim.keymap.set('n', 'C-k', vim.lsp.buf.signature_help, {})
 
         vim.keymap.set('n', 'gR', vim.lsp.buf.references, {})
@@ -55,9 +54,23 @@ return function ()
     require('lspconfig').solidity_ls_nomicfoundation.setup{
         cmd = {'nomicfoundation-solidity-language-server', '--stdio'},
         filetypes = { 'solidity' },
-        require("lspconfig.util").root_pattern "foundry.toml",
+        on_attach = attach_function,
+        require('lspconfig.util').root_pattern "foundry.toml",
         single_file_support = true,
     }
+
+--  local solhint = require("efmls-configs.linters.solhint")
+
+--  lspconfig.efm.setup({
+--      filetypes = {
+--          "solidity"
+--      },
+--      settings = {
+--          languages = {
+--              solidity = { solhint }
+--          }
+--      }
+--  })
 
     add_capabilities()
 end

--- a/lua/core/plugins.lua
+++ b/lua/core/plugins.lua
@@ -121,7 +121,10 @@ require("lazy").setup({
       config = conf('todo-comments')
     },
 	-- Tmux Navigation
-    {'christoomey/vim-tmux-navigator'},
+    {
+        'christoomey/vim-tmux-navigator',
+        lazy = false,
+    },
     {'simeji/winresizer',
         init = function() vim.g.winresizer_start_key = '<C-p>' end
     },

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -17,7 +17,7 @@ vim.opt.hlsearch = true
 vim.opt.smartcase = true
 vim.opt.incsearch = true
 vim.opt.ignorecase = true
-vim.opt.wildmode = 'longest,list,full' 
+vim.opt.wildmode = 'longest,list,full'
 vim.opt.wildmenu = true
 
 vim.opt.laststatus=2
@@ -30,8 +30,8 @@ vim.opt.fillchars = {
   vert = " ", -- set vsplit chars
 }
 
-vim.opt.guicursor = vim.opt.guicursor + 'a:-Cursor-blinkwait155-blinkoff130-blinkon155'
-vim.api.nvim_set_hl(0, 'Cursor', {reverse=true,bg='NONE',fg='NONE'})
+vim.api.nvim_set_hl(0, 'LineNr', {fg='#BFBFBF'})
+vim.api.nvim_set_hl(0, 'CursorLineNr', {fg='#FFFFFF'})
 vim.opt.breakindent = true
 vim.opt.encoding='utf-8'
 vim.opt.updatetime=750
@@ -43,7 +43,6 @@ vim.opt.wrap = true
 vim.opt.swapfile = false
 vim.opt.signcolumn='yes'
 vim.opt.number = true
-vim.opt.wrap = false
 vim.opt.rnu = true
 vim.opt.mouse='a'
 vim.opt.so = 5


### PR DESCRIPTION
This pull request introduces several updates to the Neovim configuration, including improvements to plugin management, LSP (Language Server Protocol) configurations, and UI settings. The most notable changes involve reordering Lua imports for better clarity, adding support for a new Solidity language server, and refining visual elements like line number highlighting.

### Plugin and Configuration Management:
* Reordered Lua imports in `init.lua` to ensure `core.plugins` is loaded before `core.settings` and `core.keymaps` for better organization.
* Updated the `vim-tmux-navigator` plugin in `lua/core/plugins.lua` to load eagerly by setting `lazy = false`.

### LSP Enhancements:
* Added `solidity_ls_nomicfoundation` to the list of active language servers in `lua/core/plugin_config/lsp-config.lua`.
* Updated the configuration for `solidity_ls_nomicfoundation` to include an `on_attach` callback for better integration. Commented out an unused EFM configuration for Solidity linting.

### UI and Editor Behavior:
* Adjusted line number highlighting in `lua/core/settings.lua` to improve visibility, setting `LineNr` to `#BFBFBF` and `CursorLineNr` to `#FFFFFF`.
* Removed the `wrap = false` setting in `lua/core/settings.lua`, making line wrapping default to `true`.